### PR TITLE
Fix session validator uses authority id instead of account id

### DIFF
--- a/src/handlers/session.ts
+++ b/src/handlers/session.ts
@@ -274,7 +274,7 @@ async function createOrUpdateSessionValidator(
   sessionId: string,
   input: SessionDKGAuthority
 ) {
-  const id = `${sessionId}-${input.authorityId}`
+  const id = `${sessionId}-${input.accountId}`
   logger.info(
     `Creating or updating session validator ${id} - ${input.accountId}`
   )


### PR DESCRIPTION
## Overview
The session validator uses a key combination of both session id and account id, mistakenly we used the authority id for that key