### PR TITLE
fix: updates docker and postgres init for historical data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ dist
 .DS_Store
 
 .data
+.project-cid 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       - -f=/app
       - --db-schema=app
       - --force-clean # clean the existing database (use for developement)
-      - --disable-historical=false
+      - --disable-historical=true
     healthcheck:
       test: ["CMD", "curl", "-f", "http://subquery-node:3000/ready"]
       interval: 3s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,9 @@ version: "3"
 
 services:
   postgres:
-    image: postgres:12-alpine
+    build:
+      context: .
+      dockerfile: ./docker/pg-Dockerfile
     ports:
       - 5432:5432
     volumes:
@@ -32,6 +34,7 @@ services:
       - -f=/app
       - --db-schema=app
       - --force-clean # clean the existing database (use for developement)
+      - --disable-historical=false
     healthcheck:
       test: ["CMD", "curl", "-f", "http://subquery-node:3000/ready"]
       interval: 3s

--- a/docker/load-extensions.sh
+++ b/docker/load-extensions.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<EOF
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+EOF

--- a/docker/pg-Dockerfile
+++ b/docker/pg-Dockerfile
@@ -1,0 +1,9 @@
+FROM postgres:12-alpine
+
+# Variables needed at runtime to configure postgres and run the initdb scripts
+ENV POSTGRES_DB 'postgres'
+ENV POSTGRES_USER 'postgres'
+ENV POSTGRES_PASSWORD 'postgres'
+
+# Copy in the load-extensions script
+COPY docker/load-extensions.sh /docker-entrypoint-initdb.d/

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "prepack": "rm -rf dist && npm run build",
     "test": "jest",
     "codegen": "./node_modules/.bin/subql codegen",
-    "start:docker": "docker-compose pull && docker-compose up",
+    "start:docker": "docker-compose pull && docker-compose up --remove-orphans",
     "deploy:dev": "yarn codegen && yarn build && docker-compose up",
     "ts-check": "tsc --noEmit -p ./tsconfig.json"
   },

--- a/project.yaml
+++ b/project.yaml
@@ -22,7 +22,7 @@ network:
 #  chainId: "0xe73defe42503251230e94a3dd29e3bb5d895d1f3370c132a833fcfb0d9b67c08"
   endpoint: "wss://stats-dev.api.webb.tools/public-ws" # using testnet endpoint
 #  endpoint: "ws://host.docker.internal:9944" # using docker
-  # endpoint: "ws://127.0.0.1:9944" # not using docker
+# endpoint: "ws://127.0.0.1:9944" # not using docker
 
 dataSources:
   - kind: substrate/Runtime


### PR DESCRIPTION
## Summary of changes

- Adds updates referenced in https://github.com/subquery/subql/issues/1126

Currently I have disabled the historical data in the `docker-compose.yml` file as we are not correctly handling this type of data. 