### PR TITLE
Current and next session depend on `ApiAt` session.currentSessionIndex

### DIFF
--- a/project.yaml
+++ b/project.yaml
@@ -18,7 +18,7 @@ schema:
 
 network:
   # Use Tangle network endpoint
-  chainId: "0x43ba465aa28bf187412c843233687ca7f9ab8aa2cf6769d7c9f94b536de25dea"
+  chainId: "0x8d9398e851d203128e97371e98aa329ca4bb335d17f44f78b0205cd30175ae1c"
 #  chainId: "0xe73defe42503251230e94a3dd29e3bb5d895d1f3370c132a833fcfb0d9b67c08"
   endpoint: "wss://stats-dev.api.webb.tools/public-ws" # using testnet endpoint
 #  endpoint: "ws://host.docker.internal:9944" # using docker

--- a/src/handlers/session.ts
+++ b/src/handlers/session.ts
@@ -228,12 +228,11 @@ const SESSION_HEIGHT = 10
 export async function nextSessionId(
   blockId: string
 ): Promise<{ sessionNumber: string; sessionBlock: string }> {
-  const sessionLength = await getSessionLength();
-  const blockNumber = Number(blockId)
-  const sessionNumber = Math.floor(blockNumber / sessionLength) + 1
+  const currentSessionIndex = await api.query.session.currentIndex as u32;
+
   return {
-    sessionNumber: sessionNumber.toString(),
-    sessionBlock: `${sessionNumber * sessionLength}`
+    sessionNumber: (Number(currentSessionIndex.toString()) + 1 ) .toString(),
+    sessionBlock:  blockId
   }
 }
 let sessionLength = null;
@@ -250,12 +249,10 @@ async function getSessionLength():Promise<number>{
 export async function  currentSessionId(
   blockId: string
 ): Promise<{ sessionNumber: string; sessionBlock: string }> {
-  const blockNumber = Number(blockId)
-  const sessionLength = await getSessionLength()
-  const sessionNumber = Math.floor(blockNumber / sessionLength)
+  const currentSessionIndex = await api.query.session.currentIndex as u32;
   return {
-    sessionNumber: sessionNumber.toString(),
-    sessionBlock: `${sessionNumber * sessionLength}`
+    sessionNumber: currentSessionIndex.toString(),
+    sessionBlock: blockId
   }
 }
 

--- a/src/handlers/session.ts
+++ b/src/handlers/session.ts
@@ -228,7 +228,7 @@ const SESSION_HEIGHT = 10
 export async function nextSessionId(
   blockId: string
 ): Promise<{ sessionNumber: string; sessionBlock: string }> {
-  const currentSessionIndex = await api.query.session.currentIndex as u32;
+  const currentSessionIndex = await api.query.session.currentIndex() as unknown as u32;
 
   return {
     sessionNumber: (Number(currentSessionIndex.toString()) + 1 ) .toString(),
@@ -249,7 +249,8 @@ async function getSessionLength():Promise<number>{
 export async function  currentSessionId(
   blockId: string
 ): Promise<{ sessionNumber: string; sessionBlock: string }> {
-  const currentSessionIndex = await api.query.session.currentIndex as u32;
+  const currentSessionIndex = await api.query.session.currentIndex() as unknown as u32;
+
   return {
     sessionNumber: currentSessionIndex.toString(),
     sessionBlock: blockId


### PR DESCRIPTION
# Overview
Instead of depending on constants to determine when a session gets started, the Backend will call the blockchain using `ApiAt`
