### PR TITLE
Fix uptime, added integrations with `imOnline` pallet

### DIFF
--- a/project.yaml
+++ b/project.yaml
@@ -18,7 +18,7 @@ schema:
 
 network:
   # Use Tangle network endpoint
-  chainId: "0x8d9398e851d203128e97371e98aa329ca4bb335d17f44f78b0205cd30175ae1c"
+  chainId: "0xa2514d34e63b81ffb056bcf07044c9e15552686c8793bf1bcd312de844698cde"
 #  chainId: "0xe73defe42503251230e94a3dd29e3bb5d895d1f3370c132a833fcfb0d9b67c08"
   endpoint: "wss://stats-dev.api.webb.tools/public-ws" # using testnet endpoint
 #  endpoint: "ws://host.docker.internal:9944" # using docker

--- a/project.yaml
+++ b/project.yaml
@@ -72,3 +72,9 @@ dataSources:
           filter:
             module: identity
             method: IdentitySet
+
+        - handler: handleHeartbeats
+          kind: substrate/EventHandler
+          filter:
+            module: imOnline
+            method: HeartbeatReceived

--- a/project.yaml
+++ b/project.yaml
@@ -18,7 +18,7 @@ schema:
 
 network:
   # Use Tangle network endpoint
-  chainId: "0xa2514d34e63b81ffb056bcf07044c9e15552686c8793bf1bcd312de844698cde"
+  chainId: "0x18c48b6ec39f7f3384c3b003853c40dd6f9b1501929889ae8429b9a259e7e74a"
 #  chainId: "0xe73defe42503251230e94a3dd29e3bb5d895d1f3370c132a833fcfb0d9b67c08"
   endpoint: "wss://stats-dev.api.webb.tools/public-ws" # using testnet endpoint
 #  endpoint: "ws://host.docker.internal:9944" # using docker

--- a/schema.graphql
+++ b/schema.graphql
@@ -13,6 +13,8 @@ type Block @entity {
   events: [Event] @derivedFrom(field: "block")
 }
 type HeartBeat @entity {
+  id: ID!
+
   blockNumber: BigInt!
   session:Session!
   account:Account!

--- a/schema.graphql
+++ b/schema.graphql
@@ -12,7 +12,11 @@ type Block @entity {
   extrinsics: [Extrinsic] @derivedFrom(field: "block")
   events: [Event] @derivedFrom(field: "block")
 }
-
+type HeartBeat @entity {
+  blockNumber: BigInt!
+  session:Session!
+  account:Account!
+}
 type Extrinsic @entity {
   id: ID!
 

--- a/src/handlers/account.ts
+++ b/src/handlers/account.ts
@@ -81,20 +81,23 @@ export async function RecordHeartbeat(
   authorityId: string,
   blockNumber: string
 ) {
-  const accountId = encodeAddress(authorityId)
+  const accountId = encodeAddress(authorityId ,42)
   const { sessionNumber, sessionBlock } = await currentSessionId(blockNumber)
   const heartbeatId = `${sessionNumber}-${accountId}`
   const heartbeat = await HeartBeat.get(heartbeatId)
+  logger.info(`Recording heartbeats for ${accountId}`)
   if (heartbeat) {
     logger.info(`Heartbeat already recoded for ${accountId} of session ${sessionNumber}`)
   } else {
     const session = await ensureSession(sessionNumber, sessionBlock)
     const account =await ensureAccount(accountId)
-    HeartBeat.create({
+   const hb =  HeartBeat.create({
+      id:heartbeatId,
       blockNumber: BigInt(blockNumber),
       accountId:account.id,
       sessionId: session.id
     })
+    await  hb.save()
   }
 }
 

--- a/src/handlers/account.ts
+++ b/src/handlers/account.ts
@@ -83,7 +83,7 @@ type Keys = {
 }
 let queuedKeys: Record<string, Keys> | null = null
 
-function getCachedKeys(): Promise<Record<string, Keys>> {
+export function getCachedKeys(): Promise<Record<string, Keys>> {
   const fired = queuedKeys !== null
   if (fired) {
     return Promise.resolve(queuedKeys)

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -6,7 +6,7 @@ export * from "./block"
 export * from "./event"
 export * from "./extrinsic"
 export * from "./sudo"
-
+export * from './dkg'
 export type ModuleHandlerArgs = {
   call: CallInfo
   extrinsic: SubstrateExtrinsic

--- a/src/handlers/session.ts
+++ b/src/handlers/session.ts
@@ -1,6 +1,15 @@
 import { ensureBlock } from "./block"
 import "@webb-tools/types"
-import { Proposer, Session, SessionProposer, SessionValidator, Threshold, ThresholdVariant, Validator } from "../types"
+import {
+  Account,
+  Proposer,
+  Session,
+  SessionProposer,
+  SessionValidator,
+  Threshold,
+  ThresholdVariant,
+  Validator
+} from "../types"
 import { u16, u32, Vec } from "@polkadot/types-codec"
 import { DkgRuntimePrimitivesCryptoPublic } from "@polkadot/types/lookup"
 import type { AccountId32 } from "@polkadot/types/interfaces/runtime"

--- a/src/mappings/mappingHandlers.ts
+++ b/src/mappings/mappingHandlers.ts
@@ -9,8 +9,8 @@ import {
   createEvent,
   createExtrinsic,
   createSudoCall,
-  ensureAccount,
-  UpdateOrSetIdentity,
+  ensureAccount, RecordHeartbeat,
+  UpdateOrSetIdentity
 } from "../handlers"
 import { checkAndAddAuthorities } from "../utils/authorities"
 import { checkAndAddKeygenThreshold } from "../utils/keygenThreshold"
@@ -99,4 +99,10 @@ export async function handleIdentity(event: SubstrateEvent) {
   logger.info(`IdentityHandler: ${account}`)
   const acc = await ensureAccount(account)
   return UpdateOrSetIdentity(acc)
+}
+export async function handleHeartbeats(event:SubstrateEvent){
+  const authorityId = event.event.data[0].toString()
+  const blockNumber = event.block.block.header.number.toString()
+  logger.info(`HeartBeast authorityId: ${authorityId}`)
+  return RecordHeartbeat(authorityId,blockNumber)
 }

--- a/src/types/models/index.ts
+++ b/src/types/models/index.ts
@@ -4,6 +4,8 @@
 
 export {Block} from "./Block"
 
+export {HeartBeat} from "./HeartBeat"
+
 export {Extrinsic} from "./Extrinsic"
 
 export {Event} from "./Event"


### PR DESCRIPTION
## Overview
Added the integration with `imOnline` heartbeats, to record the availability of validator/dkg authority  in a session

## checklist 
- [x] Added the event listener and handler for pallet `imOnline` event `HeartbeatReceived`
- [ ] ~Accumulate the `uptime` value in the `SessionValidator` (Client side)~