### PR TITLE
Added backend global db store  & populate the uptime value for `SessionValidator`

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -12,6 +12,16 @@ type Block @entity {
   extrinsics: [Extrinsic] @derivedFrom(field: "block")
   events: [Event] @derivedFrom(field: "block")
 }
+
+type HeartBeatCounter @jsonField {
+	authorityId:String!
+	numberOfHeartBeats:Int!
+}
+type SourceState @entity {
+	id: ID!
+	heartBeatCounters:[HeartBeatCounter!]!
+	numberOfSessions:Int!
+}
 type HeartBeat @entity {
   id: ID!
 

--- a/src/handlers/account.ts
+++ b/src/handlers/account.ts
@@ -3,8 +3,13 @@ import { Data, Option } from "@polkadot/types"
 import { PalletIdentityRegistration } from "@polkadot/types/lookup"
 import { ITuple } from "@polkadot/types-codec/types"
 import { Vec } from "@polkadot/types-codec"
-import { currentSessionId, ensureSession } from "./session"
+import {
+  currentSessionId,
+  ensureSession,
+  setSessionValidatorUptime,
+} from "./session"
 import { encodeAddress } from "@polkadot/util-crypto"
+import { addHb } from "./source"
 async function ensureCountryCode(code: string) {
   const c = await CountryCode.get(code)
   if (c) {
@@ -124,6 +129,11 @@ export async function RecordHeartbeat(imOnlineId: string, blockNumber: string) {
       sessionId: session.id,
     })
     await hb.save()
+    const [data, numberOfHeartbeats] = await addHb(accountId, "0")
+    const uptime = Math.floor(
+      (numberOfHeartbeats / data.numberOfSessions) * Math.pow(10, 7)
+    )
+    await setSessionValidatorUptime(session.id, accountId, uptime)
   }
 }
 

--- a/src/handlers/account.ts
+++ b/src/handlers/account.ts
@@ -10,6 +10,7 @@ import {
 } from "./session"
 import { encodeAddress } from "@polkadot/util-crypto"
 import { addHb } from "./source"
+import { getIntPercentage } from "../utils/int-percentage"
 async function ensureCountryCode(code: string) {
   const c = await CountryCode.get(code)
   if (c) {
@@ -106,6 +107,7 @@ export function getCachedKeys(): Promise<Record<string, Keys>> {
     })
   })
 }
+
 export async function RecordHeartbeat(imOnlineId: string, blockNumber: string) {
   const { sessionNumber, sessionBlock } = await currentSessionId(blockNumber)
   const keys = await getCachedKeys()
@@ -130,9 +132,7 @@ export async function RecordHeartbeat(imOnlineId: string, blockNumber: string) {
     })
     await hb.save()
     const [data, numberOfHeartbeats] = await addHb(accountId, "0")
-    const uptime = Math.floor(
-      (numberOfHeartbeats / data.numberOfSessions) * Math.pow(10, 7)
-    )
+    const uptime = getIntPercentage(numberOfHeartbeats, data.numberOfSessions)
     await setSessionValidatorUptime(session.id, accountId, uptime)
   }
 }

--- a/src/handlers/session.ts
+++ b/src/handlers/session.ts
@@ -342,9 +342,23 @@ export async function setSessionValidatorUptime(
   uptimeValue: number
 ) {
   const id = `${sessionId}-${accountId}`
-  const sessionValidator = new SessionValidator(id)
-  sessionValidator.uptime = uptimeValue
-  return sessionValidator.save()
+  const sessionValidator = await SessionValidator.get(id)
+  if (sessionValidator) {
+    sessionValidator.uptime = uptimeValue
+    return sessionValidator.save()
+  }
+  return createOrUpdateSessionValidator(
+    sessionId,
+    {
+      accountId,
+      authorityId: "",
+      uptime: uptimeValue,
+      isBest: true,
+      isNext: true,
+      isNextBest: true,
+    },
+    0
+  )
 }
 async function ensureProposer(accountId) {
   const proposer = await Proposer.get(accountId)

--- a/src/handlers/session.ts
+++ b/src/handlers/session.ts
@@ -17,7 +17,8 @@ import type { AccountId32 } from "@polkadot/types/interfaces/runtime"
 import { ITuple } from "@polkadot/types-codec/types"
 import { AbstractInt } from "@polkadot/types-codec/abstract/Int"
 import { ensureAccount, getCachedKeys } from "./account"
-import { increaseSourceSession } from "./source"
+import { getUptimeMap, increaseSourceSession } from "./source"
+import { getIntPercentage } from "../utils/int-percentage"
 
 /**
  * Check if the session is in the DB, if not create it
@@ -203,6 +204,7 @@ export const fetchSessionAuthorizes = async (blockNumber: string) => {
     next: currentProposerThreshold,
     pending: currentProposerThreshold,
   }
+  const [uptimeStore, storeSessionCounter] = await getUptimeMap("0")
   const inSet = (dkgAuth: DKGAuthority, set: DKGAuthority[]) =>
     set.findIndex((auth) => auth.authorityId === dkgAuth.authorityId) !== -1
   const sessionAuthorities = dkgAuthorities
@@ -215,6 +217,10 @@ export const fetchSessionAuthorizes = async (blockNumber: string) => {
           isBest: inSet(dkgAuth, bestDkgAuthorities),
           isNext: inSet(dkgAuth, nextDkgAuthorities),
           isNextBest: inSet(dkgAuth, nextBestDkgAuthorities),
+          uptime: getIntPercentage(
+            uptimeStore[dkgAuth.accountId] ?? 0,
+            storeSessionCounter
+          ),
         }
       }
     )

--- a/src/handlers/source.ts
+++ b/src/handlers/source.ts
@@ -22,26 +22,40 @@ export async function addHb(
   const source = await ensureSource(sourceId)
   let numberOfHeartbeats = 0
   let updated = false
-  for (const [index, heartBeastCounter] of source.heartBeatCounters.entries()) {
-    if (heartBeastCounter.authorityId === accountId) {
-      numberOfHeartbeats = heartBeastCounter.numberOfHeartBeats + 1
-      heartBeastCounter.numberOfHeartBeats =
-        heartBeastCounter.numberOfHeartBeats + 1
-      logger.info(
-        `Updated the heartbeat for ${accountId} to be ${numberOfHeartbeats}`
-      )
-      updated = true
-    }
-    // the entry wasn't there, it's added here
-    if (index + 1 === source.heartBeatCounters.length && !updated) {
-      numberOfHeartbeats = 1
-      logger.info(
-        `Set the heartbeat for ${accountId} to be ${numberOfHeartbeats}`
-      )
-      source.heartBeatCounters.push({
-        authorityId: accountId,
-        numberOfHeartBeats: 1,
-      })
+  if (source.heartBeatCounters.length === 0) {
+    numberOfHeartbeats = 1
+    logger.info(
+      `Set the heartbeat for ${accountId} to be ${numberOfHeartbeats}`
+    )
+    source.heartBeatCounters.push({
+      authorityId: accountId,
+      numberOfHeartBeats: 1,
+    })
+  } else {
+    for (const [
+      index,
+      heartBeastCounter,
+    ] of source.heartBeatCounters.entries()) {
+      if (heartBeastCounter.authorityId === accountId) {
+        numberOfHeartbeats = heartBeastCounter.numberOfHeartBeats + 1
+        heartBeastCounter.numberOfHeartBeats =
+          heartBeastCounter.numberOfHeartBeats + 1
+        logger.info(
+          `Updated the heartbeat for ${accountId} to be ${numberOfHeartbeats}`
+        )
+        updated = true
+      }
+      // the entry wasn't there, it's added here
+      if (index + 1 === source.heartBeatCounters.length && !updated) {
+        numberOfHeartbeats = 1
+        logger.info(
+          `Set the heartbeat for ${accountId} to be ${numberOfHeartbeats}`
+        )
+        source.heartBeatCounters.push({
+          authorityId: accountId,
+          numberOfHeartBeats: 1,
+        })
+      }
     }
   }
   await source.save()

--- a/src/handlers/source.ts
+++ b/src/handlers/source.ts
@@ -43,7 +43,7 @@ export async function addHb(
       })
     }
   }
-
+  source.heartBeatCounters = heartBeatCounters
   await source.save()
   return [source, numberOfHeartbeats]
 }

--- a/src/handlers/source.ts
+++ b/src/handlers/source.ts
@@ -45,3 +45,13 @@ export async function increaseSourceSession(sourceId: string) {
   hb.numberOfSessions = hb.numberOfSessions + 1
   return hb.save()
 }
+export async function getUptimeMap(
+  sourceId: string
+): Promise<[Record<string, number>, number]> {
+  const hb = await ensureSource(sourceId)
+  const hbMap = hb.heartBeatCounters.reduce(
+    (acc, hbc) => ({ ...acc, [hbc.authorityId]: hbc.numberOfHeartBeats }),
+    {}
+  )
+  return [hbMap, hb.numberOfSessions]
+}

--- a/src/handlers/source.ts
+++ b/src/handlers/source.ts
@@ -36,23 +36,14 @@ export async function addHb(
     }
     // the entry wasn't there, it's added here
     if (index + 1 === source.heartBeatCounters.length && !updated) {
+      numberOfHeartbeats = 1
       heartBeatCounters.push({
         authorityId: accountId,
         numberOfHeartBeats: 1,
       })
     }
   }
-  source.heartBeatCounters = source.heartBeatCounters.map((v) => {
-    if (v.authorityId === accountId) {
-      numberOfHeartbeats = v.numberOfHeartBeats + 1
-      return {
-        authorityId: accountId,
-        numberOfHeartBeats: v.numberOfHeartBeats + 1,
-      }
-    } else {
-      return v
-    }
-  })
+
   await source.save()
   return [source, numberOfHeartbeats]
 }

--- a/src/handlers/source.ts
+++ b/src/handlers/source.ts
@@ -21,6 +21,27 @@ export async function addHb(
 ): Promise<[SourceState, number]> {
   const source = await ensureSource(sourceId)
   let numberOfHeartbeats = 0
+  const heartBeatCounters = []
+  let updated = false
+  for (const [index, heartBeastCounter] of source.heartBeatCounters.entries()) {
+    if (heartBeastCounter.authorityId === accountId) {
+      numberOfHeartbeats = heartBeastCounter.numberOfHeartBeats + 1
+      heartBeatCounters.push({
+        authorityId: accountId,
+        numberOfHeartBeats: heartBeastCounter.numberOfHeartBeats + 1,
+      })
+      updated = true
+    } else {
+      heartBeatCounters.push(heartBeastCounter)
+    }
+    // the entry wasn't there, it's added here
+    if (index + 1 === source.heartBeatCounters.length && !updated) {
+      heartBeatCounters.push({
+        authorityId: accountId,
+        numberOfHeartBeats: 1,
+      })
+    }
+  }
   source.heartBeatCounters = source.heartBeatCounters.map((v) => {
     if (v.authorityId === accountId) {
       numberOfHeartbeats = v.numberOfHeartBeats + 1

--- a/src/handlers/source.ts
+++ b/src/handlers/source.ts
@@ -1,0 +1,43 @@
+import { SourceState } from "../types"
+
+export async function ensureSource(id: string) {
+  const source = await SourceState.get(id)
+  if (source) {
+    return source
+  }
+
+  const initSource = SourceState.create({
+    id,
+    numberOfSessions: 0,
+    heartBeatCounters: [],
+  })
+  await initSource.save()
+  return initSource
+}
+
+export async function addHb(
+  accountId: string,
+  sourceId: string
+): Promise<[SourceState, number]> {
+  const source = await ensureSource(sourceId)
+  let numberOfHeartbeats = 0
+  source.heartBeatCounters = source.heartBeatCounters.map((v) => {
+    if (v.authorityId === accountId) {
+      numberOfHeartbeats = v.numberOfHeartBeats + 1
+      return {
+        authorityId: accountId,
+        numberOfHeartBeats: v.numberOfHeartBeats + 1,
+      }
+    } else {
+      return v
+    }
+  })
+  await source.save()
+  return [source, numberOfHeartbeats]
+}
+
+export async function increaseSourceSession(sourceId: string) {
+  const hb = await ensureSource(sourceId)
+  hb.numberOfSessions = hb.numberOfSessions + 1
+  return hb.save()
+}

--- a/src/handlers/source.ts
+++ b/src/handlers/source.ts
@@ -21,29 +21,29 @@ export async function addHb(
 ): Promise<[SourceState, number]> {
   const source = await ensureSource(sourceId)
   let numberOfHeartbeats = 0
-  const heartBeatCounters = []
   let updated = false
   for (const [index, heartBeastCounter] of source.heartBeatCounters.entries()) {
     if (heartBeastCounter.authorityId === accountId) {
       numberOfHeartbeats = heartBeastCounter.numberOfHeartBeats + 1
-      heartBeatCounters.push({
-        authorityId: accountId,
-        numberOfHeartBeats: heartBeastCounter.numberOfHeartBeats + 1,
-      })
+      heartBeastCounter.numberOfHeartBeats =
+        heartBeastCounter.numberOfHeartBeats + 1
+      logger.info(
+        `Updated the heartbeat for ${accountId} to be ${numberOfHeartbeats}`
+      )
       updated = true
-    } else {
-      heartBeatCounters.push(heartBeastCounter)
     }
     // the entry wasn't there, it's added here
     if (index + 1 === source.heartBeatCounters.length && !updated) {
       numberOfHeartbeats = 1
-      heartBeatCounters.push({
+      logger.info(
+        `Set the heartbeat for ${accountId} to be ${numberOfHeartbeats}`
+      )
+      source.heartBeatCounters.push({
         authorityId: accountId,
         numberOfHeartBeats: 1,
       })
     }
   }
-  source.heartBeatCounters = heartBeatCounters
   await source.save()
   return [source, numberOfHeartbeats]
 }

--- a/src/handlers/source.ts
+++ b/src/handlers/source.ts
@@ -20,44 +20,22 @@ export async function addHb(
   sourceId: string
 ): Promise<[SourceState, number]> {
   const source = await ensureSource(sourceId)
-  let numberOfHeartbeats = 0
-  let updated = false
-  if (source.heartBeatCounters.length === 0) {
+  let numberOfHeartbeats
+  const hb = source.heartBeatCounters.find((hb) => hb.authorityId === accountId)
+  // set if not exist
+  if (!hb) {
     numberOfHeartbeats = 1
-    logger.info(
-      `Set the heartbeat for ${accountId} to be ${numberOfHeartbeats}`
-    )
     source.heartBeatCounters.push({
       authorityId: accountId,
       numberOfHeartBeats: 1,
     })
   } else {
-    for (const [
-      index,
-      heartBeastCounter,
-    ] of source.heartBeatCounters.entries()) {
-      if (heartBeastCounter.authorityId === accountId) {
-        numberOfHeartbeats = heartBeastCounter.numberOfHeartBeats + 1
-        heartBeastCounter.numberOfHeartBeats =
-          heartBeastCounter.numberOfHeartBeats + 1
-        logger.info(
-          `Updated the heartbeat for ${accountId} to be ${numberOfHeartbeats}`
-        )
-        updated = true
-      }
-      // the entry wasn't there, it's added here
-      if (index + 1 === source.heartBeatCounters.length && !updated) {
-        numberOfHeartbeats = 1
-        logger.info(
-          `Set the heartbeat for ${accountId} to be ${numberOfHeartbeats}`
-        )
-        source.heartBeatCounters.push({
-          authorityId: accountId,
-          numberOfHeartBeats: 1,
-        })
-      }
-    }
+    // update if  exist
+    numberOfHeartbeats = hb.numberOfHeartBeats + 1
+
+    hb.numberOfHeartBeats = hb.numberOfHeartBeats + 1
   }
+
   await source.save()
   return [source, numberOfHeartbeats]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,10 @@ import {
   KeygenThresholdArgs,
   SignatureThresholdArgs,
 } from "./handlers/dkg/dkgMetaData/types"
-
+import { ensureSource } from "./handlers/source"
+ensureSource("0").then(() => {
+  logger.info("Source created")
+})
 //Exports all handler functions
 export * from "./mappings/mappingHandlers"
 

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -2,6 +2,15 @@
 
 // Auto-generated , DO NOT EDIT
 
+export interface HeartBeatCounter {
+
+    authorityId: string;
+
+    numberOfHeartBeats: number;
+
+}
+
+
 export interface SessionKeyHistory {
 
     stage: string;

--- a/src/types/models/HeartBeat.ts
+++ b/src/types/models/HeartBeat.ts
@@ -1,0 +1,68 @@
+// Auto-generated , DO NOT EDIT
+import {Entity, FunctionPropertyNames} from "@subql/types";
+import assert from 'assert';
+
+
+
+
+type HeartBeatProps = Omit<HeartBeat, NonNullable<FunctionPropertyNames<HeartBeat>>>;
+
+export class HeartBeat implements Entity {
+
+    constructor(id: string) {
+        this.id = id;
+    }
+
+
+    public id: string;
+
+    public blockNumber: bigint;
+
+    public sessionId: string;
+
+    public accountId: string;
+
+
+    async save(): Promise<void>{
+        let id = this.id;
+        assert(id !== null, "Cannot save HeartBeat entity without an ID");
+        await store.set('HeartBeat', id.toString(), this);
+    }
+    static async remove(id:string): Promise<void>{
+        assert(id !== null, "Cannot remove HeartBeat entity without an ID");
+        await store.remove('HeartBeat', id.toString());
+    }
+
+    static async get(id:string): Promise<HeartBeat | undefined>{
+        assert((id !== null && id !== undefined), "Cannot get HeartBeat entity without an ID");
+        const record = await store.get('HeartBeat', id.toString());
+        if (record){
+            return HeartBeat.create(record as HeartBeatProps);
+        }else{
+            return;
+        }
+    }
+
+
+    static async getBySessionId(sessionId: string): Promise<HeartBeat[] | undefined>{
+      
+      const records = await store.getByField('HeartBeat', 'sessionId', sessionId);
+      return records.map(record => HeartBeat.create(record as HeartBeatProps));
+      
+    }
+
+    static async getByAccountId(accountId: string): Promise<HeartBeat[] | undefined>{
+      
+      const records = await store.getByField('HeartBeat', 'accountId', accountId);
+      return records.map(record => HeartBeat.create(record as HeartBeatProps));
+      
+    }
+
+
+    static create(record: HeartBeatProps): HeartBeat {
+        assert(typeof record.id === 'string', "id must be provided");
+        let entity = new HeartBeat(record.id);
+        Object.assign(entity,record);
+        return entity;
+    }
+}

--- a/src/types/models/SourceState.ts
+++ b/src/types/models/SourceState.ts
@@ -1,0 +1,56 @@
+// Auto-generated , DO NOT EDIT
+import {Entity, FunctionPropertyNames} from "@subql/types";
+import assert from 'assert';
+
+import {
+    HeartBeatCounter,
+} from '../interfaces'
+
+
+
+
+type SourceStateProps = Omit<SourceState, NonNullable<FunctionPropertyNames<SourceState>>>;
+
+export class SourceState implements Entity {
+
+    constructor(id: string) {
+        this.id = id;
+    }
+
+
+    public id: string;
+
+    public heartBeatCounters: HeartBeatCounter[];
+
+    public numberOfSessions: number;
+
+
+    async save(): Promise<void>{
+        let id = this.id;
+        assert(id !== null, "Cannot save SourceState entity without an ID");
+        await store.set('SourceState', id.toString(), this);
+    }
+    static async remove(id:string): Promise<void>{
+        assert(id !== null, "Cannot remove SourceState entity without an ID");
+        await store.remove('SourceState', id.toString());
+    }
+
+    static async get(id:string): Promise<SourceState | undefined>{
+        assert((id !== null && id !== undefined), "Cannot get SourceState entity without an ID");
+        const record = await store.get('SourceState', id.toString());
+        if (record){
+            return SourceState.create(record as SourceStateProps);
+        }else{
+            return;
+        }
+    }
+
+
+
+    static create(record: SourceStateProps): SourceState {
+        assert(typeof record.id === 'string', "id must be provided");
+        let entity = new SourceState(record.id);
+        Object.assign(entity,record);
+        return entity;
+    }
+}

--- a/src/types/models/index.ts
+++ b/src/types/models/index.ts
@@ -4,6 +4,8 @@
 
 export {Block} from "./Block"
 
+export {SourceState} from "./SourceState"
+
 export {HeartBeat} from "./HeartBeat"
 
 export {Extrinsic} from "./Extrinsic"

--- a/src/utils/int-percentage.ts
+++ b/src/utils/int-percentage.ts
@@ -1,0 +1,7 @@
+export function getIntPercentage(
+  numerator: number,
+  denominator: number,
+  resolution = 7
+) {
+  return Math.floor((numerator / denominator) * Math.pow(10, resolution))
+}

--- a/src/utils/int-percentage.ts
+++ b/src/utils/int-percentage.ts
@@ -1,7 +1,7 @@
 export function getIntPercentage(
   numerator: number,
   denominator: number,
-  resolution = 7
+  decimal = 9
 ) {
-  return Math.floor((numerator / denominator) * Math.pow(10, resolution))
+  return Math.floor((numerator / denominator) * Math.pow(10, decimal))
 }


### PR DESCRIPTION
## Overview
For the previous PR #37  the integration for `imOnline` pallet was introduced however there wasn't a clear way to add support for chain accumulated data.
On this PR `SourceState` entity is introduced to  store (for now ) the number of heartbeats for each validator indexed by the account and the accumulated  count of sessions

**Uptime calculation**
Utilizing `Math.floor((numerator = number of heartbeats / denominator = number of sessions) * Math.pow(10, resolution = 7))`
- Session validators for a new session will have the value from the previous session validator
- Once the validator has reported the heartbeat for the current session the value is updated for this validator
