### PR TITLE
chore: updates network's chainID

### DIFF
--- a/project.yaml
+++ b/project.yaml
@@ -18,9 +18,9 @@ schema:
 
 network:
   # Use Tangle network endpoint for Arana Alpha testnet see: https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fstats-dev.api.webb.tools%2Fpublic-ws#/settings/metadata
-  chainId: "0x18c48b6ec39f7f3384c3b003853c40dd6f9b1501929889ae8429b9a259e7e74a"
+  chainId: "0x71582117d59cf6e9143ec0b1626e48a6bbb84a95469ab1f1dc63e466d6c072d4"
   # using testnet archive node endpoint
-  endpoint: "wss://stats-dev.api.webb.tools/public-ws" 
+  endpoint: "wss://stats-dev.api.webb.tools/public-ws"
   # if you are using docker, uncomment the below line
   # endpoint: "ws://host.docker.internal:9944"
   # if you are not using Docker and want to run locally, uncomment the below line


### PR DESCRIPTION
Changes introduced in this repo:

- Updates network's chainID.

closes #42 